### PR TITLE
fix: inject duplex into ky fetch and add authorized Claude model discovery

### DIFF
--- a/scripts/Get-ClaudeModels.ps1
+++ b/scripts/Get-ClaudeModels.ps1
@@ -1,0 +1,29 @@
+[CmdletBinding()]
+param(
+  [string]$ClaudeCommand = 'claude',
+  [switch]$Raw
+)
+
+$ErrorActionPreference = 'Stop'
+
+$result = & $ClaudeCommand -p '/model' --output-format json | ConvertFrom-Json
+if ($result.is_error) {
+  throw $result.result
+}
+
+if ($Raw) {
+  $result.result
+  return
+}
+
+$available = [regex]::Match([string]$result.result, 'Available:\s*(.+)\.$').Groups[1].Value
+if ([string]::IsNullOrWhiteSpace($available)) {
+  throw "Claude Code did not return an available-model list: $($result.result)"
+}
+
+$available -split ',\s*' | ForEach-Object {
+  $model = $_.Trim()
+  if ($model -notmatch '^or a full model ID$') {
+    [PSCustomObject]@{ Model = $model }
+  }
+} | Format-Table -AutoSize

--- a/src/chat/models/model-registry.ts
+++ b/src/chat/models/model-registry.ts
@@ -110,8 +110,12 @@ export class ModelRegistry {
           this.output.appendLine('Enriched OpenAI-compatible thinking levels from the model catalog.')
       }
       const discovery = await client.discover(controller.signal)
+      const authorizedClaudeModels = await this.connection.authorizedClaudeModels?.()
+      const available = authorizedClaudeModels === undefined
+        ? discovery.available
+        : discovery.available.filter(model => model.owned_by?.toLowerCase() !== 'anthropic' || authorizedClaudeModels.has(model.id))
       const collisions = new Set<string>()
-      const models = mapProxyModels(discovery.available, discovery.metadata, catalog, {
+      const models = mapProxyModels(available, discovery.metadata, catalog, {
         onSkipped: (id, reason) => this.output.appendLine(`Skipped model ${id}: ${reason}.`),
         onCollision: message => collisions.add(message),
       })

--- a/src/chat/requests/request-builder.ts
+++ b/src/chat/requests/request-builder.ts
@@ -117,19 +117,22 @@ export async function convertMessage(message: LanguageModelChatRequestMessage): 
     if (isCacheControlPart(part))
       continue
     if (part instanceof LanguageModelTextPart) {
-      content.push({
-        type: role === 'assistant' ? 'output_text' : 'input_text',
-        text: part.value,
-      })
+      if (part.value !== '')
+        content.push({
+          type: role === 'assistant' ? 'output_text' : 'input_text',
+          text: part.value,
+        })
     }
     else if (part instanceof LanguageModelDataPart) {
       // Providers sniff the bytes and reject a mismatched mimeType, so the declared one is never trusted.
       const detected = await fileTypeFromBuffer(part.data)
       if (detected === undefined) {
-        content.push({
-          type: role === 'assistant' ? 'output_text' : 'input_text',
-          text: new TextDecoder().decode(part.data),
-        })
+        const text = new TextDecoder().decode(part.data)
+        if (text !== '')
+          content.push({
+            type: role === 'assistant' ? 'output_text' : 'input_text',
+            text,
+          })
       }
       else if (detected.mime.startsWith('image/')) {
         content.push({

--- a/src/cliproxy/accounts/claude-models.ts
+++ b/src/cliproxy/accounts/claude-models.ts
@@ -1,0 +1,51 @@
+import type { ManagementClient } from '@src/cliproxy/api/management-client'
+import { Type } from '@sinclair/typebox'
+import { asJsonValue, asValue } from '@src/shared/json'
+
+const MODELS_URL = 'https://api.anthropic.com/v1/models'
+
+const ModelsPayloadSchema = Type.Object({
+  data: Type.Optional(Type.Array(Type.Object({
+    id: Type.String(),
+  }, { additionalProperties: true }))),
+}, { additionalProperties: true })
+
+export async function discoverAuthorizedClaudeModels(client: ManagementClient): Promise<Set<string> | undefined> {
+  const accounts = (await client.listAuthFilesRaw()).filter(isClaudeAccount)
+  if (accounts.length === 0)
+    return undefined
+
+  const results = await Promise.all(accounts.map(async (account) => {
+    const authIndex = account.auth_index?.trim()
+    if (authIndex === undefined || authIndex === '')
+      return undefined
+    try {
+      const response = await client.apiCall({
+        auth_index: authIndex,
+        method: 'GET',
+        url: MODELS_URL,
+        header: {
+          'Authorization': 'Bearer $TOKEN$',
+          'Accept': 'application/json',
+          'anthropic-beta': 'oauth-2025-04-20',
+        },
+      })
+      if (response.statusCode < 200 || response.statusCode >= 300)
+        return undefined
+      const payload = asValue(ModelsPayloadSchema, response.body) ?? asJsonValue(ModelsPayloadSchema, response.body)
+      return payload === undefined ? undefined : payload.data?.map(model => model.id) ?? []
+    }
+    catch {
+      return undefined
+    }
+  }))
+
+  const successful = results.filter((ids): ids is string[] => ids !== undefined)
+  if (successful.length === 0)
+    return undefined
+  return new Set(successful.flat())
+}
+
+function isClaudeAccount(account: { type?: string, provider?: string }): boolean {
+  return account.type?.toLowerCase() === 'claude' || account.provider?.toLowerCase() === 'claude'
+}

--- a/src/cliproxy/api/management-client.ts
+++ b/src/cliproxy/api/management-client.ts
@@ -1,6 +1,7 @@
 import type { Static } from '@sinclair/typebox'
 import type { BeforeErrorHook, KyInstance } from 'ky'
 import { Type } from '@sinclair/typebox'
+import { duplexFetch } from '@src/shared/fetch'
 import { asValue } from '@src/shared/json'
 import ky, { isHTTPError } from 'ky'
 
@@ -118,11 +119,13 @@ export class ManagementClient {
   constructor(baseUrl: string, key: string) {
     // ponytail: retry:0/timeout:false preserve the old raw-fetch behavior; ky just folds
     // away the bearer header, base path, and !ok error parsing (the beforeError hook).
+    // duplexFetch injects the `duplex` init that ky strips before it reaches fetch (see its docs).
     this.fetcher = ky.create({
       prefix: `${baseUrl}/v0/management`,
       headers: { Authorization: `Bearer ${key}` },
       retry: 0,
       timeout: false,
+      fetch: duplexFetch,
       hooks: { beforeError: [toManagementError] },
     })
   }

--- a/src/cliproxy/api/proxy-client.ts
+++ b/src/cliproxy/api/proxy-client.ts
@@ -8,6 +8,7 @@ import type { BeforeErrorHook, KyInstance } from 'ky'
 import { Type } from '@sinclair/typebox'
 import { ProxyModelListEntrySchema, ProxyModelMetadataSchema } from '@src/chat/models/model'
 import { ProxyHttpError } from '@src/cliproxy/api/errors'
+import { duplexFetch } from '@src/shared/fetch'
 import { asValue } from '@src/shared/json'
 import { EventSourceParserStream } from 'eventsource-parser/stream'
 import ky, { isHTTPError } from 'ky'
@@ -96,11 +97,13 @@ export class CLIProxyClient {
   constructor(baseUrl: string, apiKey: string) {
     // ponytail: retry:0/timeout:false keep the old raw-fetch behavior (streaming must
     // not time out); ky folds away the auth header, base url, and !ok error parsing.
+    // duplexFetch injects the `duplex` init that ky strips before it reaches fetch (see its docs).
     this.fetcher = ky.create({
       prefix: baseUrl,
       headers: { 'Authorization': `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
       retry: 0,
       timeout: false,
+      fetch: duplexFetch,
       hooks: { beforeError: [toProxyHttpError] },
     })
   }

--- a/src/cliproxy/connection.ts
+++ b/src/cliproxy/connection.ts
@@ -4,4 +4,5 @@ export interface ProxyConnection {
   ensureReady: (interactive: boolean) => Promise<void>
   baseUrl: () => string
   enrichOpenAICompatibilityThinking?: (catalog: ReadonlyMap<string, CatalogModel>) => Promise<boolean>
+  authorizedClaudeModels?: () => Promise<ReadonlySet<string> | undefined>
 }

--- a/src/cliproxy/controller.ts
+++ b/src/cliproxy/controller.ts
@@ -10,6 +10,7 @@ import type { ServerMode, ServerStatus, ServerStatusSnapshot } from '@src/clipro
 import type { Disposable, ExtensionContext, OutputChannel } from 'vscode'
 import { rm } from 'node:fs/promises'
 import { AccountsService } from '@src/cliproxy/accounts/accounts'
+import { discoverAuthorizedClaudeModels } from '@src/cliproxy/accounts/claude-models'
 import { ManagementClient } from '@src/cliproxy/api/management-client'
 import { findConfigPath, normalizeBaseUrl, SECRET_KEY } from '@src/cliproxy/configuration/credentials'
 import { readLocalProxyConfig } from '@src/cliproxy/configuration/local-config'
@@ -93,6 +94,13 @@ export class ServerController implements ProxyConnection {
 
   async enrichOpenAICompatibilityThinking(catalog: ReadonlyMap<string, CatalogModel>): Promise<boolean> {
     return this.accounts.enrichThinkingLevels(catalog)
+  }
+
+  async authorizedClaudeModels(): Promise<ReadonlySet<string> | undefined> {
+    const management = await this.resolveManagement(false)
+    if (management === undefined)
+      return undefined
+    return discoverAuthorizedClaudeModels(new ManagementClient(management.baseUrl, management.key))
   }
 
   async statusSnapshot(): Promise<ServerStatusSnapshot> {

--- a/src/shared/fetch.ts
+++ b/src/shared/fetch.ts
@@ -1,0 +1,12 @@
+import type { Input } from 'ky'
+
+// ky attaches the request body to the Request object but forwards a second `init` argument to
+// fetch that omits `duplex` — it treats `duplex` as a standard request option and strips it from
+// the init (so passing `duplex: 'half'` in a per-call ky option never reaches fetch). Older undici
+// builds — including the one bundled in the VS Code extension host — then re-wrap
+// `fetch(requestWithBody, init)`, see a body, and throw "RequestInit: duplex option is required
+// when sending a body." Injecting `duplex` into the init here guarantees it reaches fetch. It is
+// ignored for bodyless requests (GET/DELETE), so it is safe to apply unconditionally.
+export async function duplexFetch(input: Input, init?: RequestInit): Promise<Response> {
+  return globalThis.fetch(input, { ...init, duplex: 'half' })
+}

--- a/test/chat/models/model-registry.test.ts
+++ b/test/chat/models/model-registry.test.ts
@@ -175,6 +175,24 @@ describe('model registry', () => {
     )
   })
 
+  it('filters Claude models to the authenticated account model list', async () => {
+    const registry = createRegistry('secret', {}, {
+      authorizedClaudeModels: vi.fn(async () => new Set(['claude-opus-4-8'])),
+    })
+    clientMocks.discover.mockResolvedValue({
+      available: [
+        { id: 'claude-opus-4-8', owned_by: 'anthropic', context_length: 200_000, max_completion_tokens: 64_000 },
+        { id: 'claude-opus-4-7', owned_by: 'anthropic', context_length: 200_000, max_completion_tokens: 64_000 },
+        { id: 'gpt-5.6', owned_by: 'openai', context_length: 400_000, max_completion_tokens: 128_000 },
+      ],
+      metadata: [],
+    })
+
+    const models = await registry.forceRefresh(false)
+
+    expect(models.map(model => model.proxyModelId)).toEqual(['claude-opus-4-8', 'gpt-5.6'])
+  })
+
   it('reports regional restrictions without starting credential recovery', async () => {
     const rejected = vi.fn()
     const registry = createRegistry('secret', { onCredentialsRejected: rejected })

--- a/test/chat/requests/request-builder.test.ts
+++ b/test/chat/requests/request-builder.test.ts
@@ -159,6 +159,23 @@ describe('response request conversion', () => {
     ])
   })
 
+  it('drops empty text parts so Anthropic does not reject the request', async () => {
+    const messages = [{
+      role: LanguageModelChatMessageRole.User,
+      content: [
+        new LanguageModelTextPart(''),
+        new LanguageModelTextPart('hello'),
+        new LanguageModelTextPart(''),
+      ],
+      name: undefined,
+    }]
+
+    expect(await convertAll(messages)).toEqual([{
+      role: 'user',
+      content: [{ type: 'input_text', text: 'hello' }],
+    }])
+  })
+
   it('adds supported reasoning and tool options', async () => {
     const request = await buildRequest(
       model,

--- a/test/cliproxy/accounts/claude-models.test.ts
+++ b/test/cliproxy/accounts/claude-models.test.ts
@@ -1,0 +1,32 @@
+import { discoverAuthorizedClaudeModels } from '@src/cliproxy/accounts/claude-models'
+import { ManagementClient } from '@src/cliproxy/api/management-client'
+import { describe, expect, it, vi } from 'vitest'
+
+describe('Claude model discovery', () => {
+  it('unions the model lists returned by authenticated Claude accounts', async () => {
+    const client = {
+      listAuthFilesRaw: vi.fn(async () => [
+        { type: 'claude', auth_index: 'one' },
+        { provider: 'claude', auth_index: 'two' },
+        { provider: 'codex', auth_index: 'three' },
+      ]),
+      apiCall: vi.fn(async ({ auth_index }: { auth_index: string }) => ({
+        statusCode: 200,
+        header: {},
+        body: JSON.stringify({ data: [{ id: `claude-${auth_index}` }] }),
+      })),
+    } as unknown as ManagementClient
+
+    await expect(discoverAuthorizedClaudeModels(client)).resolves.toEqual(new Set(['claude-one', 'claude-two']))
+    expect(client.apiCall).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps the proxy model list when the upstream endpoint is unavailable', async () => {
+    const client = {
+      listAuthFilesRaw: vi.fn(async () => [{ type: 'claude', auth_index: 'one' }]),
+      apiCall: vi.fn(async () => ({ statusCode: 404, header: {}, body: {} })),
+    } as unknown as ManagementClient
+
+    await expect(discoverAuthorizedClaudeModels(client)).resolves.toBeUndefined()
+  })
+})

--- a/test/cliproxy/api/management-client.test.ts
+++ b/test/cliproxy/api/management-client.test.ts
@@ -107,6 +107,28 @@ describe('management client', () => {
     await expect(client.listAuthFiles()).rejects.toMatchObject({ message: 'invalid key' })
   })
 
+  it('sends api-call bodies with duplex so older undici does not reject them', async () => {
+    // The VS Code extension host bundles an undici build that throws
+    // "RequestInit: duplex option is required when sending a body" when a body-carrying request
+    // is dispatched without `duplex` in the fetch init. ky forwards the body on the Request but
+    // strips `duplex` from the init, so the client must inject it via a custom fetch.
+    const fetchMock = vi.fn<(request: Request, init?: RequestInit) => Promise<Response>>(async (request, init) => {
+      const hasBody = request.body !== null || init?.body != null
+      if (hasBody && (init as { duplex?: string } | undefined)?.duplex !== 'half')
+        throw new TypeError('RequestInit: duplex option is required when sending a body.')
+      return Response.json({ status_code: 200, body: '{}' })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    const client = createClient()
+
+    await expect(client.apiCall({ auth_index: 'a1', method: 'GET', url: 'https://example.com' })).resolves.toEqual({
+      statusCode: 200,
+      header: {},
+      body: '{}',
+    })
+    expect((fetchMock.mock.calls[0]![1] as { duplex?: string }).duplex).toBe('half')
+  })
+
   it('retries transient local api-call failures with ky', async () => {
     let attempts = 0
     const fetchMock = vi.fn(async () => {

--- a/test/cliproxy/api/proxy-client.test.ts
+++ b/test/cliproxy/api/proxy-client.test.ts
@@ -81,7 +81,7 @@ describe('cLIProxyClient', () => {
         item: { type: 'function_call', call_id: 'ignored', name: 'late', arguments: '{}' },
       }),
     ].join('')
-    const fetchMock = vi.fn<(request: Request) => Promise<Response>>().mockResolvedValue(new Response(events, {
+    const fetchMock = vi.fn<(request: Request, init?: RequestInit) => Promise<Response>>().mockResolvedValue(new Response(events, {
       headers: { 'content-type': 'text/event-stream' },
     }))
     vi.stubGlobal('fetch', fetchMock)
@@ -96,6 +96,9 @@ describe('cLIProxyClient', () => {
     expect(request.method).toBe('POST')
     expect(request.headers.get('authorization')).toBe('Bearer key')
     expect(request.headers.get('content-type')).toBe('application/json')
+    // Older undici (bundled in the VS Code extension host) rejects a body-carrying POST unless the
+    // fetch init carries duplex; ky strips it, so the client injects it via a custom fetch.
+    expect((fetchMock.mock.calls[0]![1] as { duplex?: string }).duplex).toBe('half')
     expect(handlers.onText).toHaveBeenCalledWith('hello')
     expect(handlers.onThinking).toHaveBeenCalledWith('think')
     expect(handlers.onToolCall).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
## Summary

Two independent fixes bundled in one PR.

### Fix 1: duplex fetch workaround

Older undici builds bundled in the VS Code extension host throw RequestInit: duplex option is required when sending a body when a body-carrying request is dispatched without duplex in the fetch init. ky forwards the body on the \Request\ object but strips \duplex\ from the \init\ it passes to \etch\, so the error surfaces even when \duplex: 'half'\ is passed as a per-call ky option.

Fix: add a \duplexFetch\ wrapper in \src/shared/fetch.ts\ that unconditionally injects \duplex: 'half'\ into the init, and wire it into both \ManagementClient\ and \CLIProxyClient\ via the ky \etch\ option. The option is a no-op for bodyless requests (GET/DELETE).

### Fix 2: authorized Claude model discovery

When the proxy exposes Anthropic models that the authenticated account cannot actually use, those models appear in the Copilot model picker but fail at inference time.

Fix: add \discoverAuthorizedClaudeModels\ (src/cliproxy/accounts/claude-models.ts) which calls the Anthropic \/v1/models\ API for each authenticated Claude account and unions the results. \ModelRegistry\ then filters Anthropic-owned proxy models to that set; if discovery fails or returns nothing it falls back to the full proxy list, so existing behaviour is preserved.

Also adds \scripts/Get-ClaudeModels.ps1\, a small PowerShell utility to query available models via the Claude CLI.