### PR TITLE
fix: preserve duplex through VS Code proxy fetch

### DIFF
--- a/src/cliproxy/api/management-client.ts
+++ b/src/cliproxy/api/management-client.ts
@@ -2,6 +2,7 @@ import type { Static } from '@sinclair/typebox'
 import type { BeforeErrorHook, KyInstance } from 'ky'
 import { Type } from '@sinclair/typebox'
 import { asValue } from '@src/shared/json'
+import { vscodeCompatibleFetch } from '@src/shared/vscode-fetch'
 import ky, { isHTTPError } from 'ky'
 
 export const LOGIN_PROVIDERS = [
@@ -124,6 +125,7 @@ export class ManagementClient {
       retry: 0,
       timeout: false,
       hooks: { beforeError: [toManagementError] },
+      fetch: vscodeCompatibleFetch,
     })
   }
 

--- a/src/cliproxy/api/proxy-client.ts
+++ b/src/cliproxy/api/proxy-client.ts
@@ -10,6 +10,7 @@ import { ProxyModelListEntrySchema, ProxyModelMetadataSchema } from '@src/chat/m
 import { ProxyHttpError } from '@src/cliproxy/api/errors'
 import { asValue } from '@src/shared/json'
 import { isHttpUrl } from '@src/shared/url'
+import { vscodeCompatibleFetch } from '@src/shared/vscode-fetch'
 import { EventSourceParserStream } from 'eventsource-parser/stream'
 import ky, { isHTTPError } from 'ky'
 
@@ -140,6 +141,7 @@ export class CLIProxyClient {
       retry: 0,
       timeout: false,
       hooks: { beforeError: [toProxyHttpError] },
+      fetch: vscodeCompatibleFetch,
     })
   }
 

--- a/src/shared/vscode-fetch.ts
+++ b/src/shared/vscode-fetch.ts
@@ -1,0 +1,11 @@
+/**
+ * Keeps `duplex` when VS Code's proxy-aware fetch adds a dispatcher.
+ *
+ * In Node.js 24 / Undici 7, reconstructing a Request with a stream body and no
+ * `duplex` in the init object throws before the request is sent.
+ */
+export const vscodeCompatibleFetch: typeof fetch = async (input, init) => {
+  if (input instanceof Request && input.body && init?.duplex === undefined)
+    init = { ...init, duplex: 'half' }
+  return fetch(input, init)
+}

--- a/test/shared/vscode-fetch.test.ts
+++ b/test/shared/vscode-fetch.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('vscodeCompatibleFetch', () => {
+  it('passes duplex when forwarding a Request with a body', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(new Response())
+    vi.stubGlobal('fetch', fetchMock)
+    const { vscodeCompatibleFetch } = await import('@src/shared/vscode-fetch')
+    const request = new Request('http://proxy/v1/responses', {
+      method: 'POST',
+      body: new ReadableStream(),
+      duplex: 'half',
+    })
+
+    await vscodeCompatibleFetch(request)
+
+    expect(fetchMock).toHaveBeenCalledWith(request, { duplex: 'half' })
+  })
+
+  it('preserves an explicitly supplied duplex option', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(new Response())
+    vi.stubGlobal('fetch', fetchMock)
+    const { vscodeCompatibleFetch } = await import('@src/shared/vscode-fetch')
+    const request = new Request('http://proxy/v1/responses', {
+      method: 'POST',
+      body: new ReadableStream(),
+      duplex: 'half',
+    })
+    const init: RequestInit = { duplex: 'half' }
+
+    await vscodeCompatibleFetch(request, init)
+
+    expect(fetchMock).toHaveBeenCalledWith(request, init)
+  })
+})


### PR DESCRIPTION
Closes #129

## Summary

Adds a shared `vscodeCompatibleFetch` wrapper for the two CLIProxyAPI `ky` clients. The wrapper forwards `duplex: 'half'` when VS Code's proxy-aware fetch receives a body-bearing `Request` with no duplex in the accompanying init object.

This is a narrow compatibility mitigation for the VS Code extension-host proxy-fetch / Node.js 24 Undici interaction described in #129. It does not affect GET requests and preserves an explicitly provided duplex value.

## Changes

- add `src/shared/vscode-fetch.ts`
- use the shared wrapper in `CLIProxyClient` and `ManagementClient`
- add focused regression tests for missing and explicit duplex values

## Validation

- `pnpm check`
- rebuilt and deployed the extension locally
- confirmed a Universal Chat Provider chat request reaches CLIProxyAPI and streams a response in VS Code Insiders