### PR TITLE
feat: send a stable X-Session-Id header on completion requests

### DIFF
--- a/src/chat/provider.ts
+++ b/src/chat/provider.ts
@@ -20,7 +20,7 @@ import { ModelRegistry } from '@src/chat/models/model-registry'
 import { detectCompaction } from '@src/chat/requests/compaction'
 import { streamCompletion } from '@src/chat/requests/completion'
 import { estimateTokens } from '@src/chat/requests/estimate'
-import { buildRequest } from '@src/chat/requests/request-builder'
+import { buildRequest, buildSessionId } from '@src/chat/requests/request-builder'
 import { CredentialStore } from '@src/cliproxy/configuration/credentials'
 import { remainingForModel } from '@src/cliproxy/quota/quota'
 import { errorMessage } from '@src/shared/errors'
@@ -135,6 +135,7 @@ export class UniversalChatProvider implements LanguageModelChatProvider<Provider
       if (entries.length > 0)
         sections.push({ title: 'Antigravity', entries })
     }
+
     return sections
   }
 
@@ -152,6 +153,7 @@ export class UniversalChatProvider implements LanguageModelChatProvider<Provider
       await this.credentialFlows.showOnboarding()
       return
     }
+
     await this.registry.forceRefresh(false)
   }
 
@@ -167,6 +169,7 @@ export class UniversalChatProvider implements LanguageModelChatProvider<Provider
       await this.onSignIn()
       return withUtilityAliases(await this.registry.forceRefresh(false))
     }
+
     return withUtilityAliases(await this.registry.refresh(!options.silent, token))
   }
 
@@ -199,6 +202,7 @@ export class UniversalChatProvider implements LanguageModelChatProvider<Provider
       omitTools: compaction !== undefined,
       webSearch,
     })
+    const sessionId = buildSessionId(messages)
     const citations: WebCitation[] = []
     const recordUsage = this.cacheMetrics.start({
       model: targetModel.proxyModelId,
@@ -228,6 +232,7 @@ export class UniversalChatProvider implements LanguageModelChatProvider<Provider
           },
         },
         token,
+        sessionId,
       )
       if (citations.length > 0)
         progress.report(new LanguageModelTextPart(formatCitations(citations)))

--- a/src/chat/requests/completion.ts
+++ b/src/chat/requests/completion.ts
@@ -18,6 +18,7 @@ export async function streamCompletion(
   body: ProxyRequestBody,
   callbacks: StreamCallbacks,
   token?: CancellationToken,
+  sessionId?: string,
 ): Promise<void> {
   await deps.connection.ensureReady(false)
   const apiKey = await deps.credentials.get()
@@ -30,7 +31,7 @@ export async function streamCompletion(
 
   try {
     const client = new CLIProxyClient(deps.connection.baseUrl(), apiKey)
-    await client.streamResponse(body, callbacks, controller.signal)
+    await client.streamResponse(body, callbacks, controller.signal, sessionId)
   }
   catch (error) {
     if (token?.isCancellationRequested)
@@ -54,5 +55,6 @@ function mapProviderError(error: unknown): Error {
     if (error.status === 429)
       return LanguageModelError.Blocked(error.message)
   }
+
   return error instanceof Error ? error : new Error(String(error))
 }

--- a/src/chat/requests/request-builder.ts
+++ b/src/chat/requests/request-builder.ts
@@ -99,18 +99,27 @@ export function buildPromptCacheKey(
   model: ProviderModel,
   messages: readonly LanguageModelChatRequestMessage[],
 ): string | undefined {
+  const hash = seedHash(messages, model.proxyModelId)
+  return hash === undefined ? undefined : `universal-chat-provider-${hash}`
+}
+
+// Unsalted by model so it stays stable if the user switches models mid-conversation.
+export function buildSessionId(messages: readonly LanguageModelChatRequestMessage[]): string | undefined {
+  return seedHash(messages, 'session')
+}
+
+function seedHash(messages: readonly LanguageModelChatRequestMessage[], salt: string): string | undefined {
   const seed = sessionSeed(messages)
   if (seed === undefined)
     return undefined
 
-  const hash = createHash('sha256')
+  return createHash('sha256')
     .update('universal-chat-provider:prompt-cache:v1\0')
-    .update(model.proxyModelId)
+    .update(salt)
     .update('\0')
     .update(seed)
     .digest('hex')
     .slice(0, 32)
-  return `universal-chat-provider-${hash}`
 }
 
 function isCacheControlPart(part: unknown): boolean {
@@ -188,6 +197,7 @@ export function serializeToolResult(part: LanguageModelToolResultPart): string {
         ? new TextDecoder().decode(value.data)
         : `[${value.mimeType} data]`
     }
+
     return JSON.stringify(value)
   }).join('\n')
 }
@@ -227,6 +237,7 @@ function partFingerprint(part: LanguageModelChatRequestMessage['content'][number
       return `data:${part.mimeType}:${new TextDecoder().decode(part.data)}`
     return `data:${part.mimeType}:${createHash('sha256').update(part.data).digest('hex')}`
   }
+
   if (part instanceof LanguageModelToolResultPart)
     return `tool-result:${part.callId}:${serializeToolResult(part)}`
   if (part instanceof LanguageModelToolCallPart)

--- a/src/cliproxy/api/proxy-client.ts
+++ b/src/cliproxy/api/proxy-client.ts
@@ -5,6 +5,7 @@ import type {
 } from '@src/chat/models/model'
 import type { ProxyRequestBody } from '@src/chat/requests/request-builder'
 import type { BeforeErrorHook, KyInstance } from 'ky'
+import { randomUUID } from 'node:crypto'
 import { Type } from '@sinclair/typebox'
 import { ProxyModelListEntrySchema, ProxyModelMetadataSchema } from '@src/chat/models/model'
 import { ProxyHttpError } from '@src/cliproxy/api/errors'
@@ -156,10 +157,14 @@ export class CLIProxyClient {
     body: ProxyRequestBody,
     callbacks: StreamCallbacks,
     signal: AbortSignal,
+    sessionId?: string,
   ): Promise<void> {
+    // Some providers behind CLIProxyAPI (e.g. OpenCode Go) require a stable session header for
+    // sticky routing; fall back to a random id so requests without a derivable seed still carry one.
     const response = await this.fetcher.post('/v1/responses', {
       json: body,
       signal,
+      headers: { 'X-Session-Id': sessionId ?? randomUUID() },
     })
     if (!response.body)
       throw new Error('CLIProxyAPI returned an empty streaming response.')
@@ -185,6 +190,7 @@ export class CLIProxyClient {
       catch {
         continue
       }
+
       if (payload === undefined)
         continue
       const type = payload.type ?? event.event
@@ -235,11 +241,13 @@ export class CLIProxyClient {
             pending.delete(key)
             continue
           }
+
           const current = pending.get(key) ?? {
             callId: item.call_id ?? key,
             name: item.name ?? 'unknown_tool',
             arguments: '',
           }
+
           current.arguments = item.arguments ?? current.arguments
           emitToolCall(current, callbacks, emitted)
         }
@@ -258,6 +266,7 @@ export class CLIProxyClient {
           if (parsed !== undefined)
             emitItemCitations(parsed, callbacks, citations)
         }
+
         callbacks.onUsage?.(completed?.usage)
       }
       else if (type === 'response.incomplete') {
@@ -369,6 +378,7 @@ function thinkingSentinelFilter(emit?: (delta: string) => void): { push: (delta:
           return
         }
       }
+
       flush(value)
     },
     end() {
@@ -403,6 +413,7 @@ function emitToolCall(
       input = { raw: call.arguments }
     }
   }
+
   callbacks.onToolCall(call.callId, call.name, input)
 }
 

--- a/test/chat/provider.test.ts
+++ b/test/chat/provider.test.ts
@@ -80,6 +80,7 @@ describe('language model provider', () => {
       }),
       expect.any(Object),
       expect.any(AbortSignal),
+      expect.any(String),
     )
     const thinkingPart = report.mock.calls[0]?.[0] as LanguageModelThinkingPart
     expect(thinkingPart).toBeInstanceOf(LanguageModelThinkingPart)
@@ -163,6 +164,7 @@ describe('language model provider', () => {
       expect.objectContaining({ reasoning: { effort: 'xhigh', summary: 'detailed' } }),
       expect.any(Object),
       expect.any(AbortSignal),
+      expect.any(String),
     )
     expect(vscodeMock.output.appendLine).toHaveBeenCalledWith(
       '[usage] model-a: effort=xhigh input=0 cached=n/a write=0 output=1 hit=n/a raw={"output_tokens":1}',
@@ -481,6 +483,7 @@ describe('conversation compaction', () => {
       }),
       expect.any(Object),
       expect.any(AbortSignal),
+      expect.any(String),
     )
     expect(requestBody()).not.toHaveProperty('tools')
     expect(requestBody()).not.toHaveProperty('tool_choice')
@@ -501,6 +504,7 @@ describe('conversation compaction', () => {
       }),
       expect.any(Object),
       expect.any(AbortSignal),
+      expect.any(String),
     )
   })
 
@@ -525,6 +529,7 @@ describe('conversation compaction', () => {
       }),
       expect.any(Object),
       expect.any(AbortSignal),
+      expect.any(String),
     )
     expect(requestBody()).not.toHaveProperty('tools')
   })
@@ -551,6 +556,7 @@ describe('conversation compaction', () => {
       }),
       expect.any(Object),
       expect.any(AbortSignal),
+      expect.any(String),
     )
     expect(requestBody()).toHaveProperty('tools')
   })

--- a/test/chat/requests/completion.test.ts
+++ b/test/chat/requests/completion.test.ts
@@ -36,6 +36,19 @@ describe('streamCompletion', () => {
     expect(release).toHaveBeenCalledOnce()
   })
 
+  it('forwards the session id to the proxy client', async () => {
+    clientMocks.streamResponse.mockResolvedValueOnce(undefined)
+
+    await streamCompletion(deps('key'), emptyBody, callbacks(), undefined, 'session-123')
+
+    expect(clientMocks.streamResponse).toHaveBeenCalledWith(
+      emptyBody,
+      expect.any(Object),
+      expect.any(AbortSignal),
+      'session-123',
+    )
+  })
+
   it('requires credentials', async () => {
     await expect(streamCompletion(deps(), emptyBody, callbacks())).rejects.toMatchObject({
       code: 'NoPermissions',

--- a/test/chat/requests/request-builder.test.ts
+++ b/test/chat/requests/request-builder.test.ts
@@ -1,5 +1,5 @@
 import { Buffer } from 'node:buffer'
-import { buildPromptCacheKey, buildRequest, convertMessage } from '@src/chat/requests/request-builder'
+import { buildPromptCacheKey, buildRequest, buildSessionId, convertMessage } from '@src/chat/requests/request-builder'
 import { describe, expect, it } from 'vitest'
 import {
   LanguageModelChatMessageRole,
@@ -304,6 +304,30 @@ describe('response request conversion', () => {
     expect((await buildRequest(model, firstTurn, {
       toolMode: LanguageModelChatToolMode.Auto,
     })).prompt_cache_key).toBe(key)
+  })
+
+  it('keeps the session id stable across turns and model switches', async () => {
+    const firstTurn = [userTextMessage('hello')]
+    const secondTurn = [
+      ...firstTurn,
+      {
+        role: LanguageModelChatMessageRole.Assistant,
+        content: [new LanguageModelTextPart('hi')],
+        name: undefined,
+      },
+      userTextMessage('next'),
+    ]
+    const otherModel = createProviderModel({ proxyModelId: 'other-model' })
+
+    const sessionId = buildSessionId(firstTurn)
+
+    expect(sessionId).toMatch(/^[a-f0-9]{32}$/)
+    expect(buildSessionId(secondTurn)).toBe(sessionId)
+    expect(buildPromptCacheKey(otherModel, firstTurn)).not.toContain(sessionId)
+  })
+
+  it('has no session id when messages carry no derivable seed', () => {
+    expect(buildSessionId([])).toBeUndefined()
   })
 
   it('falls back to a supported reasoning level and supplies a default tool schema', async () => {

--- a/test/cliproxy/api/proxy-client.test.ts
+++ b/test/cliproxy/api/proxy-client.test.ts
@@ -123,11 +123,26 @@ describe('cLIProxyClient', () => {
     expect(request.method).toBe('POST')
     expect(request.headers.get('authorization')).toBe('Bearer key')
     expect(request.headers.get('content-type')).toBe('application/json')
+    expect(request.headers.get('x-session-id')).toEqual(expect.any(String))
     expect(handlers.onText).toHaveBeenCalledWith('hello')
     expect(handlers.onThinking).toHaveBeenCalledWith('think')
     expect(handlers.onToolCall).toHaveBeenCalledTimes(1)
     expect(handlers.onToolCall).toHaveBeenCalledWith('call-1', 'lookup', { q: 'x' })
     expect(handlers.onUsage).toHaveBeenCalledWith({ input_tokens: 10, output_tokens: 2 })
+  })
+
+  it('sends a stable session header when a session id is provided', async () => {
+    const fetchMock = vi.fn<(request: Request) => Promise<Response>>().mockResolvedValue(new Response('data: [DONE]\n\n', {
+      headers: { 'content-type': 'text/event-stream' },
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+    const { CLIProxyClient } = await import('@src/cliproxy/api/proxy-client')
+
+    await new CLIProxyClient('http://proxy', 'key')
+      .streamResponse({ model: 'x' } as ProxyRequestBody, callbacks(), new AbortController().signal, 'session-123')
+
+    const request = fetchMock.mock.calls[0]![0]
+    expect(request.headers.get('x-session-id')).toBe('session-123')
   })
 
   it('collects hosted search citations without emitting a local tool call', async () => {
@@ -185,6 +200,7 @@ describe('cLIProxyClient', () => {
       start_index: 0,
       end_index: 4,
     }
+
     const body = [
       event({
         type: 'response.content_part.done',


### PR DESCRIPTION
## Why

Some providers routed through CLIProxyAPI require a stable, per-conversation session identifier for sticky routing (e.g. OpenCode Go started rejecting requests without one). CLIProxyAPI relies on the client to send it, but the extension currently only sends `Authorization` and `Content-Type` headers.

## What changed

- Added `buildSessionId(messages)` in `request-builder.ts`, sharing the same hashing core (`seedHash`) already used by `buildPromptCacheKey`, but **unsalted by model** — so the session id stays stable even if the user switches models mid-conversation (unlike the prompt cache key, which is intentionally salted per model).
- Threaded the derived session id through `provider.ts` → `streamCompletion` → `CLIProxyClient.streamResponse`.
- `CLIProxyClient.streamResponse` now sends a generic `X-Session-Id` header (not provider-specific) on every `/v1/responses` request, falling back to `randomUUID()` when no seed can be derived from the message history (e.g. empty history).

## Testing

- `pnpm vitest run`, `pnpm lint`, `pnpm typecheck` all pass.
- Added test coverage for: session id stability across conversation turns, stability across model switches, `undefined` fallback when no seed is derivable, and the resulting HTTP header (explicit value + random fallback).
- Manually verified end-to-end against a local CLIProxyAPI instance in external mode talking to OpenCode Go: `X-Session-Id` is sent by the extension, and CLIProxyAPI forwards it as `X-Opencode-Session` upstream, staying stable across multiple messages in the same conversation.
