### PR TITLE
fix: allow setting the external management key manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ The extension runs [CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI) l
 | `universalChatProvider.resetServer`      | Universal Chat Provider: Reset Managed Server                                        |
 | `universalChatProvider.configure`        | Universal Chat Provider: Configure Connection                                        |
 | `universalChatProvider.importConfig`     | Universal Chat Provider: Import API Key from Config                                  |
+| `universalChatProvider.setManagementKey` | Universal Chat Provider: Set Management Key                                          |
 | `universalChatProvider.refresh`          | Universal Chat Provider: Refresh Models                                              |
 | `universalChatProvider.setUtilityModel`  | Universal Chat Provider: Set Utility Model (commit messages, chat titles, summaries) |
 | `universalChatProvider.clearCredentials` | Universal Chat Provider: Clear Stored API Key                                        |

--- a/package.json
+++ b/package.json
@@ -87,6 +87,10 @@
         "title": "Universal Chat Provider: Import API Key from Config"
       },
       {
+        "command": "universalChatProvider.setManagementKey",
+        "title": "Universal Chat Provider: Set Management Key"
+      },
+      {
         "command": "universalChatProvider.refresh",
         "title": "Universal Chat Provider: Refresh Models"
       },

--- a/src/cliproxy/controller.ts
+++ b/src/cliproxy/controller.ts
@@ -170,6 +170,22 @@ export class ServerController implements ProxyConnection {
     return this.accounts.manageAccounts()
   }
 
+  async setManagementKey(): Promise<void> {
+    const value = await window.showInputBox({
+      title: 'Management Key',
+      // CLIProxyAPI bcrypt-hashes remote-management.secret-key on startup, so the plaintext
+      // only survives in config.yaml until the server's first launch; store it here instead.
+      prompt: 'Enter the CLIProxyAPI management key.',
+      password: true,
+      ignoreFocusOut: true,
+      validateInput: input => input.trim() ? undefined : 'A management key is required.',
+    })
+    if (value === undefined || value.length === 0)
+      return
+    await this.context.secrets.store(MGMT_KEY_SECRET, value.trim())
+    void window.showInformationMessage('Management key saved.')
+  }
+
   async listCodexResets(): Promise<CodexResetOption[]> {
     const management = await this.resolveManagement(false)
     if (management === undefined)

--- a/src/extension/commands.ts
+++ b/src/extension/commands.ts
@@ -42,6 +42,7 @@ export function registerCommands(
     { command: 'universalChatProvider.resetServer', run: async () => controller.resetServer(), group: 2, modes: ['managed'], label: '$(discard) Reset Managed Server', description: 'Recreate the config and keys' },
     { command: 'universalChatProvider.configure', run: async () => provider.configure(), group: 2, modes: ['external'], label: '$(settings-gear) Configure Connection', description: 'Set the proxy URL and config path' },
     { command: 'universalChatProvider.importConfig', run: async () => provider.importConfig(), group: 2, modes: ['external'], label: '$(key) Import API Key from Config', description: 'Load an API key from config.yaml' },
+    { command: 'universalChatProvider.setManagementKey', run: async () => controller.setManagementKey(), group: 2, modes: ['external'], label: '$(shield) Set Management Key', description: 'Store the plaintext key before CLIProxyAPI hashes it' },
     { command: 'universalChatProvider.openSettings', run: async () => commands.executeCommand('workbench.action.openSettings', `@ext:${extensionId}`), group: 3, label: '$(gear) Open Settings', description: 'Edit this extension\'s settings' },
     { command: 'universalChatProvider.showLogs', run: () => output.show(true), group: 3, label: '$(output) Show Extension Logs', description: 'Diagnostics from the extension itself' },
     { command: 'universalChatProvider.clearCredentials', run: async () => {

--- a/test/cliproxy/controller.test.ts
+++ b/test/cliproxy/controller.test.ts
@@ -441,6 +441,25 @@ describe('server controller status snapshot', () => {
     expect(snapshot).toMatchObject({ mode: 'external', status: 'external', baseUrl: 'http://127.0.0.1:9' })
     expect(snapshot.accounts).toBeUndefined()
   })
+
+  it('stores a trimmed management key from the prompt', async () => {
+    const controller = new ServerController(context(root), vscodeMock.output as never, vscodeMock.output as never)
+    window.showInputBox.mockResolvedValueOnce('  mgmt-secret  ')
+
+    await controller.setManagementKey()
+
+    expect(vscodeMock.secrets.get('universalChatProvider.managementKey')).toBe('mgmt-secret')
+    expect(window.showInformationMessage).toHaveBeenCalledWith('Management key saved.')
+  })
+
+  it('does nothing when the management key prompt is cancelled', async () => {
+    const controller = new ServerController(context(root), vscodeMock.output as never, vscodeMock.output as never)
+    window.showInputBox.mockResolvedValueOnce(undefined)
+
+    await controller.setManagementKey()
+
+    expect(vscodeMock.secrets.get('universalChatProvider.managementKey')).toBeUndefined()
+  })
 })
 
 function context(root: string): ExtensionContext {

--- a/test/extension/commands.test.ts
+++ b/test/extension/commands.test.ts
@@ -34,6 +34,7 @@ describe('registerCommands', () => {
     ['manageAccounts', (harness: CommandHarness) => harness.controller.manageAccounts],
     ['configure', (harness: CommandHarness) => harness.provider.configure],
     ['importConfig', (harness: CommandHarness) => harness.provider.importConfig],
+    ['setManagementKey', (harness: CommandHarness) => harness.controller.setManagementKey],
     ['restartServer', (harness: CommandHarness) => harness.controller.restartServer],
     ['updateBinary', (harness: CommandHarness) => harness.controller.updateBinary],
     ['resetServer', (harness: CommandHarness) => harness.controller.resetServer],
@@ -179,6 +180,7 @@ function createCommandHarness() {
     restartServer: vi.fn(async () => {}),
     updateBinary: vi.fn(async () => {}),
     resetServer: vi.fn(async () => {}),
+    setManagementKey: vi.fn(async () => {}),
   }
   const output = createOutputChannelMock('Universal Chat Provider')
   const serverOutput = createOutputChannelMock('CLIProxyAPI Server')

--- a/test/extension/index.test.ts
+++ b/test/extension/index.test.ts
@@ -26,7 +26,7 @@ describe('extension activation', () => {
 
     expect(activate(context)).toBeUndefined()
     expect(vscodeMock.registeredProviders[0]).toMatchObject({ vendor: 'universal-chat-provider' })
-    expect(vscodeMock.commandHandlers).toHaveLength(15)
+    expect(vscodeMock.commandHandlers).toHaveLength(16)
     expect(initialize).toHaveBeenCalledTimes(1)
     await vi.waitFor(() => expect(refreshQuotas).toHaveBeenCalledTimes(1))
     expect(setRefreshListener).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
## Why

In external server mode, "Manage Accounts", "Show Quota", and other management commands fail with `invalid management key`, even after using "Import API Key from Config".

CLIProxyAPI bcrypt-hashes `remote-management.secret-key` on startup and rewrites `config.yaml` with the hash (confirmed in [`config_load.go`](https://github.com/router-for-me/CLIProxyAPI/blob/main/internal/config/config_load.go)), so the plaintext value only exists momentarily before the server's first launch. The management server itself still expects the plaintext value in the `Authorization`/`X-Management-Key` header and compares it against the stored bcrypt hash — that part works fine.

The gap is on the extension side: nothing ever gave the user a way to provide that plaintext key in external mode.

- `Import API Key from Config` (`credentials.ts`) only imports the chat `api-keys` entry, never `remote-management.secret-key`.
- `externalManagementKey()` in `controller.ts` already checks a `SecretStorage` override (`MGMT_KEY_SECRET`) before falling back to reading `config.yaml`, but that override was only ever written by `provisionManagedState()` in managed mode — nothing wrote it in external mode.
- Once `config.yaml` gets hashed (near-immediately after the server's first start), reading it directly is a dead end (`local-config.ts` already correctly ignores bcrypt-looking values via the `$2` prefix check).

## What changed

Added a `Set Management Key` command (`universalChatProvider.setManagementKey`), visible only in external mode, that prompts for the plaintext key and stores it via the same `SecretStorage` override already read by `externalManagementKey()`. No changes to the read path or the HTTP protocol — this only adds the missing write path.

## Testing

- `pnpm vitest run`, `pnpm lint`, `pnpm typecheck` all pass.
- Added tests for the happy path (trims and stores the key, shows a confirmation) and prompt cancellation.
- Manually verified end-to-end: set a plaintext key via the new command against a local CLIProxyAPI instance in external mode (after its `config.yaml` had already been hashed), then successfully ran Manage Accounts / Show Quota.
