### PR TITLE
fix(managed): fall back to cached binary when release resolution fails

### DIFF
--- a/src/cliproxy/managed/binary.ts
+++ b/src/cliproxy/managed/binary.ts
@@ -72,7 +72,17 @@ interface AcquireResult {
 }
 
 export async function acquireBinary(options: AcquireOptions): Promise<AcquireResult> {
-  const version = await resolveVersion(options.requestedVersion, options.signal)
+  let version: string
+  try {
+    version = await resolveVersion(options.requestedVersion, options.signal)
+  }
+  catch (error) {
+    const cachedVersion = await readInstalledVersion(options.binDir)
+    if (cachedVersion === undefined)
+      throw error
+    options.output.appendLine(`Could not resolve latest CLIProxyAPI release (${error instanceof Error ? error.message : String(error)}). Using cached CLIProxyAPI ${cachedVersion}.`)
+    version = cachedVersion
+  }
   const asset = resolveAsset(osPlatform(), osArch(), version)
   const versionDir = join(options.binDir, version)
   const binaryPath = join(versionDir, asset.binaryName)

--- a/test/cliproxy/managed/binary.test.ts
+++ b/test/cliproxy/managed/binary.test.ts
@@ -1,9 +1,10 @@
-import { mkdir, readFile } from 'node:fs/promises'
+import type { OutputChannel } from 'vscode'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
-import { extractArchive, normalizeVersion, parseChecksums, readInstalledVersion, resolveAsset } from '@src/cliproxy/managed/binary'
+import { acquireBinary, extractArchive, normalizeVersion, parseChecksums, readInstalledVersion, resolveAsset } from '@src/cliproxy/managed/binary'
 import { zipSync } from 'fflate'
 import { createTarGzip } from 'nanotar'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useTempDirectories } from '../../support/temp'
 
 const makeTempDirectory = useTempDirectories()
@@ -86,5 +87,49 @@ describe('readInstalledVersion', () => {
     await mkdir(join(binDir, '7.10.0'))
     await mkdir(join(binDir, 'tmp'))
     expect(await readInstalledVersion(binDir)).toBe('7.10.0')
+  })
+})
+
+describe('acquireBinary', () => {
+  let binDir: string
+  const output = { appendLine: vi.fn(), append: vi.fn() } as unknown as OutputChannel
+
+  beforeEach(async () => {
+    binDir = await makeTempDirectory('ucp-bin-')
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('uses cached binary when release resolution fails (e.g. rate limit)', async () => {
+    const version = '7.2.5'
+    const asset = resolveAsset(process.platform, process.arch, version)
+    const versionDir = join(binDir, version)
+    await mkdir(versionDir, { recursive: true })
+    const binaryPath = join(versionDir, asset.binaryName)
+    await writeFile(binaryPath, 'mock binary')
+
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(new Response('rate limit exceeded', { status: 403 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await acquireBinary({
+      binDir,
+      requestedVersion: 'latest',
+      output,
+    })
+
+    expect(result).toEqual({ binaryPath, version })
+  })
+
+  it('rethrows error when release resolution fails and no cached binary exists', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(new Response('rate limit exceeded', { status: 403 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(acquireBinary({
+      binDir,
+      requestedVersion: 'latest',
+      output,
+    })).rejects.toThrow()
   })
 })


### PR DESCRIPTION
### Problem

When `acquireBinary` runs with `requestedVersion: 'latest'` (the default), it attempts to resolve the latest GitHub release via `https://api.github.com/repos/router-for-me/CLIProxyAPI/releases/latest`.

If unauthenticated GitHub API rate limits are exceeded (e.g. HTTP 403 `rate limit exceeded`), or if the GitHub API is temporarily unavailable/unreachable, `resolveVersion` throws an error. Currently, this failure aborts binary acquisition immediately and prevents the managed server from starting, even when a valid, working CLIProxyAPI binary is already installed and present in the local cache directory (`options.binDir`).

### Solution

In `acquireBinary`, catch errors from `resolveVersion` and check `readInstalledVersion(options.binDir)`. If a cached version is available, log a diagnostic message and fall back to using that cached version instead of aborting startup. If no cached version exists, the original error is rethrown.

### Testing

- Added unit tests in `test/cliproxy/managed/binary.test.ts` verifying that `acquireBinary` falls back to the cached binary when release resolution fails (e.g. 403 rate limit) and rethrows if no cache exists.
- Verified all unit tests, TypeScript typechecking, and ESLint pass cleanly (`vitest`, `tsc --noEmit`, `eslint`).